### PR TITLE
update api uri

### DIFF
--- a/lib/coinbase/exchange/api_client.rb
+++ b/lib/coinbase/exchange/api_client.rb
@@ -3,7 +3,7 @@ module Coinbase
     # Net-http client for Coinbase Exchange API
     class APIClient
       def initialize(api_key = '', api_secret = '', api_pass = '', options = {})
-        @api_uri = URI.parse(options[:api_url] || "https://api.gdax.com")
+        @api_uri = URI.parse(options[:api_url] || "https://api.pro.coinbase.com")
         @api_pass = api_pass
         @api_key = api_key
         @api_secret = api_secret


### PR DESCRIPTION
 Calls to api.gdax.com will now automatically redirect to api.pro.coinbase.com. 
On May 15, 2019 api.gdax.com will be fully deprecated. Please update your trading scripts accordingly.